### PR TITLE
[kaizen] Navn på vedlegg som matcher kontrakten

### DIFF
--- a/src/innsending/saga.ts
+++ b/src/innsending/saga.ts
@@ -161,9 +161,9 @@ const mapStateToKontraktSøknad = (
                     barnehageDato,
                     barnehageKommune,
                     barnehageStatus: soknad.barnehageplass.barnBarnehageplassStatus.verdi,
+                    barnehageVedlegg: vedlegg,
                     fødselsnummer: barn.fødselsnummer,
                     navn: barn.fulltnavn,
-                    vedlegg,
                 })
             )
         ),

--- a/src/innsending/types.ts
+++ b/src/innsending/types.ts
@@ -29,9 +29,9 @@ export interface IKontraktBarn {
     barnehageDato: string;
     barnehageKommune: string;
     barnehageStatus: string;
+    barnehageVedlegg: string[];
     fødselsnummer: string;
     navn: string;
-    vedlegg: string[];
 }
 
 export interface IOppgittFamilieforhold {


### PR DESCRIPTION
I kontrakten heter vedleggene "barnehageVedlegg". Endrer her slik at navn matcher kontrakten - hvis ikke klarer man ikke deserialisere søknader med vedlegg. 